### PR TITLE
refactor: correct a variable name

### DIFF
--- a/src/CommandsCollection/typo3/web/dcc-init
+++ b/src/CommandsCollection/typo3/web/dcc-init
@@ -17,11 +17,11 @@ printf "${reset}${cyan}[DCC]${reset} DDEV Commands Collection\n"
 
 echo
 echo -e "${magenta}[CONFIG]${reset}"
-read -p $"Initialize TYPO3 instanz? (y|N) " INIT_SYMFONY
+read -p $"Initialize TYPO3 instanz? (y|N) " INIT_TYPO3
 read -p $"Sync database (stage-to-local)? (y|N) " SYNC_DB
 read -p $"Build assets? (y|N) " INSTALL_ASSETS
 
-if [[ $INIT_SYMFONY =~ ^[Yy]$ ]]
+if [[ $INIT_TYPO3 =~ ^[Yy]$ ]]
 then
     echo -e "${blue}[INFO]${reset} Install TYPO3 instance"
     cd ${composerPathApp}


### PR DESCRIPTION
Change a variable name inside TYPO3 specific script from "INIT_SYMFONY" to "INIT_TYPO3" in order to prevent confusion.
This is not a functional change - just cosmetics.