### PR TITLE
fix: composer commands without param should display composer script options instead of throwing an error 

### DIFF
--- a/src/CommandsCollection/drupal/web/dcc-composer-app
+++ b/src/CommandsCollection/drupal/web/dcc-composer-app
@@ -14,5 +14,5 @@ printf "${reset}${cyan}[DCC]${reset} DDEV Commands Collection\n"
 ## Description: Executes 'composer' commands in app
 ## Usage: composer:app
 ## Example: "ddev composer:app i"
-printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}composer $@ -d ${composerPathApp}${reset}\n"
-composer $@ -d ${composerPathApp}
+printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}composer $@ --working-dir=${composerPathApp}${reset}\n"
+composer $@ --working-dir=${composerPathApp}

--- a/src/CommandsCollection/drupal/web/dcc-composer-deployment
+++ b/src/CommandsCollection/drupal/web/dcc-composer-deployment
@@ -14,5 +14,5 @@ printf "${reset}${cyan}[DCC]${reset} DDEV Commands Collection\n"
 ## Description: Executes 'composer' commands in projectroot
 ## Usage: composer:deployment
 ## Example: "ddev composer:deployment i"
-printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}composer $@ -d ${composerPathDeployment}${reset}\n"
-composer $@ -d  ${composerPathDeployment}
+printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}composer $@ --working-dir=${composerPathDeployment}${reset}\n"
+composer $@ --working-dir=${composerPathDeployment}

--- a/src/CommandsCollection/symfony/web/dcc-composer-app
+++ b/src/CommandsCollection/symfony/web/dcc-composer-app
@@ -14,5 +14,5 @@ printf "${reset}${cyan}[DCC]${reset} DDEV Commands Collection\n"
 ## Description: Executes 'composer' commands in app
 ## Usage: composer:app
 ## Example: "ddev composer:app i"
-printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}composer $@ -d ${composerPathApp}${reset}\n"
-composer $@ -d ${composerPathApp}
+printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}composer $@ --working-dir=${composerPathApp}${reset}\n"
+composer $@ --working-dir=${composerPathApp}

--- a/src/CommandsCollection/symfony/web/dcc-composer-deployment
+++ b/src/CommandsCollection/symfony/web/dcc-composer-deployment
@@ -14,5 +14,5 @@ printf "${reset}${cyan}[DCC]${reset} DDEV Commands Collection\n"
 ## Description: Executes 'composer' commands in projectroot
 ## Usage: composer:deployment
 ## Example: "ddev composer:deployment i"
-printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}composer $@ -d ${composerPathDeployment}${reset}\n"
-composer $@ -d  ${composerPathDeployment}
+printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}composer $@ --working-dir=${composerPathDeployment}${reset}\n"
+composer $@ --working-dir=${composerPathDeployment}

--- a/src/CommandsCollection/typo3/web/dcc-composer-app
+++ b/src/CommandsCollection/typo3/web/dcc-composer-app
@@ -14,5 +14,5 @@ printf "${reset}${cyan}[DCC]${reset} DDEV Commands Collection\n"
 ## Description: Executes 'composer' commands in app
 ## Usage: composer:app
 ## Example: "ddev composer:app i"
-printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}composer $@ -d ${composerPathApp}${reset}\n"
-composer $@ -d ${composerPathApp}
+printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}composer $@ --working-dir=${composerPathApp}${reset}\n"
+composer $@ --working-dir=${composerPathApp}

--- a/src/CommandsCollection/typo3/web/dcc-composer-deployment
+++ b/src/CommandsCollection/typo3/web/dcc-composer-deployment
@@ -14,5 +14,5 @@ printf "${reset}${cyan}[DCC]${reset} DDEV Commands Collection\n"
 ## Description: Executes 'composer' commands in projectroot
 ## Usage: composer:deployment
 ## Example: "ddev composer:deployment i"
-printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}composer $@ -d ${composerPathDeployment}${reset}\n"
-composer $@ -d  ${composerPathDeployment}
+printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}composer $@ --working-dir=${composerPathDeployment}${reset}\n"
+composer $@ --working-dir=${composerPathDeployment}


### PR DESCRIPTION
replace -d with --working-dir= to prevent error and correctly display composer script list when called without param like 'ddev composer:app'