### PR TITLE
fix: make init script work on first run without database

### DIFF
--- a/src/CommandsCollection/typo3/web/dcc-init
+++ b/src/CommandsCollection/typo3/web/dcc-init
@@ -28,11 +28,13 @@ then
     cp .env.ddev.dist .env
     echo -e "${blue}[INFO]${reset} Install dependencies"
     printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}composer install${reset}\n"
-    composer install
+    composer install --no-scripts
 
     echo -e "${blue}[INFO]${reset} Setup TYPO3"
     printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}php vendor/bin/typo3cms install:setup --no-interaction --skip-integrity-check${reset}\n"
     php vendor/bin/typo3cms install:setup --no-interaction --skip-integrity-check
+
+    composer typo3-cms-scripts
 
     echo -e "${green}[OK]${reset} TYPO3 instance installed"
 fi


### PR DESCRIPTION
TYPO3: With the new project structure with just one composer file the init command fails in first run because database does not exist jet and composer scripts try to setup TYPO3 stuff. 
This fix runs composer install with --no-scripts parameter and runs the typo scripts after initial project setup (which creates a database).