### PR TITLE
feat: add command "dep" as a shortcut to run deployer

### DIFF
--- a/src/CommandsCollection/general/static/web/dep
+++ b/src/CommandsCollection/general/static/web/dep
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+## Description: Using deployer command inside ddev web container
+## Usage: dep
+## Example: "ddev dep"
+
+dep $@


### PR DESCRIPTION
Please check if this is the right place to put the cammand. I was wondering because the section is called "static"