### PR TITLE
[breaking] typo3cms binary was removed so we need to adapt

### DIFF
--- a/src/CommandsCollection/typo3/web/dcc-cc
+++ b/src/CommandsCollection/typo3/web/dcc-cc
@@ -14,5 +14,5 @@ printf "${reset}${cyan}[DCC]${reset} DDEV Commands Collection\n"
 ## Description: Executes clear flush console command
 ## Usage: cc
 ## Example: "ddev cc" or "ddev cc -g all"
-printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}php ${composerPathApp}/vendor/bin/typo3cms cache:flush $@${reset}\n"
-php ${composerPathApp}/vendor/bin/typo3cms cache:flush $@
+printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}php ${composerPathApp}/vendor/bin/typo3 cache:flush $@${reset}\n"
+php ${composerPathApp}/vendor/bin/typo3 cache:flush $@

--- a/src/CommandsCollection/typo3/web/dcc-console
+++ b/src/CommandsCollection/typo3/web/dcc-console
@@ -14,5 +14,5 @@ printf "${reset}${cyan}[DCC]${reset} DDEV Commands Collection\n"
 ## Description: Executes TYPO3 console command
 ## Usage: console
 ## Example: "ddev console cache:flush"
-printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}php ${composerPathApp}/vendor/bin/typo3cms $@${reset}\n"
-php ${composerPathApp}/vendor/bin/typo3cms $@
+printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}php ${composerPathApp}/vendor/bin/typo3 $@${reset}\n"
+php ${composerPathApp}/vendor/bin/typo3 $@

--- a/src/CommandsCollection/typo3/web/dcc-init
+++ b/src/CommandsCollection/typo3/web/dcc-init
@@ -31,8 +31,8 @@ then
     composer install
 
     echo -e "${blue}[INFO]${reset} Setup TYPO3"
-    printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}php vendor/bin/typo3cms install:setup --no-interaction --skip-integrity-check${reset}\n"
-    php vendor/bin/typo3cms install:setup --no-interaction --skip-integrity-check
+    printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}php vendor/bin/typo3 install:setup --no-interaction --skip-integrity-check${reset}\n"
+    php vendor/bin/typo3 install:setup --no-interaction --skip-integrity-check
 
     echo -e "${green}[OK]${reset} TYPO3 instance installed"
 fi
@@ -43,8 +43,8 @@ then
     printf "${reset}${cyan}[DCC]${reset}${reset}<web> ${black}db_sync_tool -f ${composerPathDeployment}/../deployment/db-sync-tool/sync-${defaultSyncSystem}-to-local.${defaultSyncFileEnding}${reset}\n"
     db_sync_tool -f ${composerPathDeployment}/../deployment/db-sync-tool/sync-${defaultSyncSystem}-to-local.${defaultSyncFileEnding}
 
-    ${composerPathApp}/bin/typo3cms database:updateschema
-    ${composerPathApp}/bin/typo3cms cache:flush
+    ${composerPathApp}/bin/typo3 database:updateschema
+    ${composerPathApp}/bin/typo3 cache:flush
     # display faq section
     sh "$(dirname "$0")/../faq/dcc-faq-web-sync.sh"
 fi


### PR DESCRIPTION
helhum/typo3_console switched to typo3 default binary in version 8.0.
So composer/bin/typo3cms becomes composer/bin/typo3 for all console calls.